### PR TITLE
Added metadata check to enable plugins to bypass entity overrides

### DIFF
--- a/src/main/java/com/ericdebouwer/zombieapocalypse/zombie/ZombieListener.java
+++ b/src/main/java/com/ericdebouwer/zombieapocalypse/zombie/ZombieListener.java
@@ -34,7 +34,7 @@ public class ZombieListener implements Listener{
 		if (!(e.getEntity() instanceof Monster)) return;
 		
 		if (e.getEntity() instanceof Zombie && ZombieType.getType((Zombie) e.getEntity()) != null) return;
-		
+		if (e.getEntity().hasMetadata("ignoreZombie")) return;
 		e.setCancelled(true);
 		plugin.getZombieFactory().spawnZombie(e.getLocation());
 	}


### PR DESCRIPTION
This allows plugins to bypass the apocalypse overriding all entity spawns. Alternative methods can be unnecessarily complex, this commit makes ZombieApocalypse ignore entities spawned with a metadata key of "ignoreZombie". Note that this requires the usage of <T extends Entity> World#spawn(Location, Class<T>, Consumer<T>) to assign metadata value before CreatureSpawnEvent is called.