### PR TITLE
Fix NPE if a PDC does not have a zombieTypeKey

### DIFF
--- a/src/main/java/com/ericdebouwer/zombieapocalypse/zombie/ZombieItems.java
+++ b/src/main/java/com/ericdebouwer/zombieapocalypse/zombie/ZombieItems.java
@@ -46,7 +46,7 @@ public class ZombieItems {
         if (container == null) return null;
         try {
             return ZombieType.valueOf(container.getPersistentDataContainer().get(zombieTypeKey, PersistentDataType.STRING));
-        } catch (IllegalArgumentException | NullPointerException ila){
+        } catch (IllegalArgumentException | NullPointerException ex){
             return null;
         }
     }

--- a/src/main/java/com/ericdebouwer/zombieapocalypse/zombie/ZombieItems.java
+++ b/src/main/java/com/ericdebouwer/zombieapocalypse/zombie/ZombieItems.java
@@ -46,7 +46,7 @@ public class ZombieItems {
         if (container == null) return null;
         try {
             return ZombieType.valueOf(container.getPersistentDataContainer().get(zombieTypeKey, PersistentDataType.STRING));
-        } catch (IllegalArgumentException ila){
+        } catch (IllegalArgumentException | NullPointerException ila){
             return null;
         }
     }


### PR DESCRIPTION
Original Error:

Caused by: java.lang.NullPointerException: Name is null
        at java.lang.Enum.valueOf(Enum.java:271) ~[?:?]